### PR TITLE
build and release for ascend minio image

### DIFF
--- a/Dockerfile.ascend
+++ b/Dockerfile.ascend
@@ -1,0 +1,40 @@
+FROM golang:1.12-alpine as build
+
+LABEL maintainer="Ascend.io <team-eng-infra@ascend.io>"
+
+ENV GOPATH /go
+ENV CGO_ENABLED 0
+ENV GO111MODULE on
+
+COPY . /go/src/github.com/ascend.io/minio
+
+RUN  apk add --no-cache git && \
+     cd /go/src/github.com/ascend.io/minio && \
+     go install -v -ldflags "$(go run buildscripts/gen-ldflags.go)" && \
+     cd dockerscripts; go build -tags kqueue -ldflags "-s -w" -o /usr/bin/healthcheck healthcheck.go && \
+     go build -tags kqueue -ldflags "-s -w" -o /usr/bin/check-user check-user.go
+
+FROM alpine:3.9
+
+ENV MINIO_UPDATE off
+ENV MINIO_ACCESS_KEY_FILE=access_key \
+    MINIO_SECRET_KEY_FILE=secret_key
+
+EXPOSE 9000
+
+COPY --from=build /go/bin/minio /usr/bin/minio
+COPY --from=build /usr/bin/healthcheck /usr/bin/healthcheck
+COPY --from=build /usr/bin/check-user /usr/bin/check-user
+COPY dockerscripts/docker-entrypoint.sh /usr/bin/
+
+RUN  \
+     apk add --no-cache ca-certificates 'curl>7.61.0' 'su-exec>=0.2' && \
+     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
+
+ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
+
+VOLUME ["/data"]
+
+HEALTHCHECK --interval=1m CMD healthcheck
+
+CMD ["minio"]

--- a/build-and-push-ascend.sh
+++ b/build-and-push-ascend.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+DOCKER_TAG=v0.1
+
+MINIO_TAG=ascend-io/minio-gateway:$DOCKER_TAG
+
+GCP_PROJECT=ascend-io-ops-artifacts
+
+MINIO_GCR_TAG=gcr.io/$GCP_PROJECT/$MINIO_TAG
+
+function build() {
+  docker build -t $MINIO_TAG \
+    -f Dockerfile.ascend \
+    .
+  docker tag $MINIO_TAG $MINIO_GCR_TAG
+}
+
+function push() {
+  # Auth
+  gcloud auth login
+  gcloud config set project $GCP_PROJECT
+  gcloud auth configure-docker
+
+  # Minio push
+  docker push $MINIO_GCR_TAG
+}
+
+build
+push


### PR DESCRIPTION
Motivation:

We need to be able to iterate on a custom minio image, which means deploying our own image to GCR.

Changes:

This adds a new dockerfile to customize the build (not pulling from minio/minio source), and push to our central artifacts registry in GCR.

Tests:

[x]: Deploy our image in my devenv